### PR TITLE
Explicitly add the md5 digest hashfunction default,

### DIFF
--- a/javatests/com/google/devtools/javatools/jade/pkgloader/LibTest.java
+++ b/javatests/com/google/devtools/javatools/jade/pkgloader/LibTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.javatools.jade.pkgloader;
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
@@ -34,7 +35,7 @@ public class LibTest {
   private static final PackageLoaderFactory PACKAGE_LOADER_FACTORY =
       new BazelPackageLoaderFactory();
 
-  private static final FileSystem FILESYSTEM = new InMemoryFileSystem();
+  private static final FileSystem FILESYSTEM = new InMemoryFileSystem(DigestHashFunction.MD5);
   private Path workspaceRoot;
   private Path installBase;
   private Path outputBase;

--- a/javatests/com/google/devtools/javatools/jade/pkgloader/SerializerTest.java
+++ b/javatests/com/google/devtools/javatools/jade/pkgloader/SerializerTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.packages.Package;
 import com.google.devtools.build.lib.skyframe.packages.PackageLoader;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
@@ -45,7 +46,7 @@ public class SerializerTest {
 
   @Before
   public void setUp() throws IOException {
-    FileSystem fs = new InMemoryFileSystem();
+    FileSystem fs = new InMemoryFileSystem(DigestHashFunction.MD5);
     workspaceRoot = fs.getPath("/workspace/");
     Path installBase = fs.getPath("/install_base/");
     Path outputBase = fs.getPath("/output_base/");


### PR DESCRIPTION
 to allow empty constructor to be removed